### PR TITLE
TTL is required for Append/Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2022-12-11
+### Fixed
+  - TTL for Append/Set defaults to 3600 seconds if no value is provided
+
 ## [1.0.0] - 2022-11-28
 ### Added
   - support for DNS record types: A, CNAME, MX, NS, TXT

--- a/client.go
+++ b/client.go
@@ -486,6 +486,11 @@ type providerResponse struct {
 func buildPayload(rec libdns.Record) providerPayload {
 	var payload providerPayload
 
+	// Total Uptime does not accept TTLs set to 0
+	if rec.TTL == 0 {
+		rec.TTL = 3600 * time.Second
+	}
+
 	switch rec.Type {
 	case "A":
 		payload.AHostName = rec.Name

--- a/provider_test.go
+++ b/provider_test.go
@@ -305,7 +305,7 @@ func TestSetRecords(t *testing.T) {
 			Type:  "TXT",
 			Name:  "test-TXT-domain",
 			Value: "test-TXT-value",
-			TTL:   3600 * time.Second,
+			// acme challenge does not provide a TTL
 		},
 	}
 


### PR DESCRIPTION
This PR adjusts for an issue related to the ACME DNS Solver routine... it seems that it is trying to create a DCV TXT record without setting TTL. Total Uptime API does not accept a 0 value for this.

I've confirmed that this small provider adjustment corrects the problem here. See log entries below.
Thank you

```
2022/12/11 17:09:08 ca.go:226: Issue certificate #7/8 from Digicert: testonly-donder.redacted.com [totaluptime]
1.6707965485327423e+09	info	obtain	acquiring lock	{"identifier": "testonly-donder.redacted.com"}
1.6707965485456727e+09	info	obtain	lock acquired	{"identifier": "testonly-donder.redacted.com"}
1.6707965485457497e+09	info	obtain	obtaining certificate	{"identifier": "testonly-donder.redacted.com"}
1.6707965487501853e+09	info	waiting on internal rate limiter	{"identifiers": ["testonly-donder.redacted.com"], "ca": "https://acme.digicert.com/v2/acme/directory/", "account": "noc@redacted.com"}
1.6707965487502062e+09	info	done waiting on internal rate limiter	{"identifiers": ["testonly-donder.redacted.com"], "ca": "https://acme.digicert.com/v2/acme/directory/", "account": "noc@redacted.com"}
1.6707965490864885e+09	info	acme_client	trying to solve challenge	{"identifier": "testonly-donder.redacted.com", "challenge_type": "dns-01", "ca": "https://acme.digicert.com/v2/acme/directory/"}
2022/12/11 17:09:09 provider.go:186: DNS append failure with provider message: Invalid TTL. 
1.6707965498813636e+09	error	acme_client	cleaning up solver	{"identifier": "testonly-donder.redacted.com", "challenge_type": "dns-01", "error": "no memory of presenting a DNS record for \"_acme-challenge.testonly-donder.redacted.com\" (usually OK if presenting also failed)"}
1.6707965499358485e+09	error	acme_client	deactivating authorization	{"identifier": "testonly-donder.redacted.com", "authz": "https://acme.digicert.com/v2/acme/authz/__redacted__/qmYvRGT7K1cu8FeP", "error": "attempt 1: https://acme.digicert.com/v2/acme/authz/__redacted__/qmYvRGT7K1cu8FeP: HTTP 400 urn:ietf:params:acme:error:malformed - payload field of the JWS object must be the empty string"}
1.6707965499359503e+09	error	obtain	could not get certificate from issuer	{"identifier": "testonly-donder.redacted.com", "issuer": "acme.digicert.com-v2-acme-directory", "error": "[testonly-donder.redacted.com] solving challenges: presenting for challenge: expected one record, got 0: [] (order=https://acme.digicert.com/v2/acme/order/__redacted__/nzsPau4HI8ppFPuTC1VOamgztuoUR_9pSrWABkTsEDY) (ca=https://acme.digicert.com/v2/acme/directory/)"}
1.670796549936011e+09	info	obtain	releasing lock	{"identifier": "testonly-donder.redacted.com"}
2022/12/11 17:09:09 logic.go:56: testonly-donder.redacted.com: obtaining certificate: [testonly-donder.redacted.com] Obtain: [testonly-donder.redacted.com] solving challenges: presenting for challenge: expected one record, got 0: [] (order=https://acme.digicert.com/v2/acme/order/__redacted__/nzsPau4HI8ppFPuTC1VOamgztuoUR_9pSrWABkTsEDY) (ca=https://acme.digicert.com/v2/acme/directory/)
2022/12/11 17:09:09 ca.go:226: Issue certificate #8/8 from Digicert: testonly-blitzen.redacted.com [totaluptime]
1.6707965499375637e+09	info	obtain	acquiring lock	{"identifier": "testonly-blitzen.redacted.com"}
1.6707965499505494e+09	info	obtain	lock acquired	{"identifier": "testonly-blitzen.redacted.com"}
1.6707965499506755e+09	info	obtain	obtaining certificate	{"identifier": "testonly-blitzen.redacted.com"}
1.6707965500911508e+09	info	waiting on internal rate limiter	{"identifiers": ["testonly-blitzen.redacted.com"], "ca": "https://acme.digicert.com/v2/acme/directory/", "account": "noc@redacted.com"}
1.6707965500911837e+09	info	done waiting on internal rate limiter	{"identifiers": ["testonly-blitzen.redacted.com"], "ca": "https://acme.digicert.com/v2/acme/directory/", "account": "noc@redacted.com"}
1.6707965504350448e+09	info	acme_client	trying to solve challenge	{"identifier": "testonly-blitzen.redacted.com", "challenge_type": "dns-01", "ca": "https://acme.digicert.com/v2/acme/directory/"}
2022/12/11 17:09:10 provider.go:186: DNS append failure with provider message: Invalid TTL. 
1.6707965506997771e+09	error	acme_client	cleaning up solver	{"identifier": "testonly-blitzen.redacted.com", "challenge_type": "dns-01", "error": "no memory of presenting a DNS record for \"_acme-challenge.testonly-blitzen.redacted.com\" (usually OK if presenting also failed)"}
1.6707965507567635e+09	error	acme_client	deactivating authorization	{"identifier": "testonly-blitzen.redacted.com", "authz": "https://acme.digicert.com/v2/acme/authz/__redacted__/JM_sqyuPlef_5A0f", "error": "attempt 1: https://acme.digicert.com/v2/acme/authz/__redacted__/JM_sqyuPlef_5A0f: HTTP 400 urn:ietf:params:acme:error:malformed - payload field of the JWS object must be the empty string"}
1.6707965507569082e+09	error	obtain	could not get certificate from issuer	{"identifier": "testonly-blitzen.redacted.com", "issuer": "acme.digicert.com-v2-acme-directory", "error": "[testonly-blitzen.redacted.com] solving challenges: presenting for challenge: expected one record, got 0: [] (order=https://acme.digicert.com/v2/acme/order/__redacted__/jmNKhyF93iylzppC5fTrr6wkn9ZM52-Rhn-_g_xfmqk) (ca=https://acme.digicert.com/v2/acme/directory/)"}
1.6707965507569735e+09	info	obtain	releasing lock	{"identifier": "testonly-blitzen.redacted.com"}
2022/12/11 17:09:10 logic.go:56: testonly-blitzen.redacted.com: obtaining certificate: [testonly-blitzen.redacted.com] Obtain: [testonly-blitzen.redacted.com] solving challenges: presenting for challenge: expected one record, got 0: [] (order=https://acme.digicert.com/v2/acme/order/__redacted__/jmNKhyF93iylzppC5fTrr6wkn9ZM52-Rhn-_g_xfmqk) (ca=https://acme.digicert.com/v2/acme/directory/)
```